### PR TITLE
Добавлены release notes (автоматические)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,13 @@
-name: Release
+# .github/release.yml
 
-on:
-  push:
-    tags:
-      - "v*"
-
-jobs:
-  release:
-    name: "Release"
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
Сначала в гитхабе, затем в гите через файл (он ниже)

[](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
я так понял, они автоматически должны проставляться...

Вопрос вот в чем. Я также нашел такие видео:
[](https://www.youtube.com/watch?v=-0vWW-ymlfw)
или [](https://www.youtube.com/watch?v=_ueJ3LrRqPU)

я так понимаю они использовали старый репо на github.actions:
https://github.com/actions/create-release/blob/main/README.md

Какой - рабочий вариант и как убедиться, что мой (новый) - рабочий ? Потому что по логике, это должно было обновиться:

![изображение](https://github.com/gpb-it-factory/khasmamedov-telergam-bot/assets/25296074/1a40effb-c823-467d-9e32-08fbf597179f)

Но обновления я не вижу.
